### PR TITLE
Remove gpg from homebrew and rely on GPG Tools

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -15,7 +15,7 @@ run() {
 #/ homebrews       Installs core homebrew kegs
 homebrews() {
   printf "%sInstalling homebrews..\n"
-  brew install bash-completion ctags git gpg heroku hub macvim ripgrep tidy-html5 tree watchman wget yarn
+  brew install bash-completion ctags git heroku hub macvim ripgrep tidy-html5 tree watchman wget yarn
 }
 
 #/ nvm             Installs node version manager
@@ -77,7 +77,7 @@ vim() {
 #/ casks           Installs non App Store Mac applications
 casks() {
   printf "%sInstalling homebrew casks..\n"
-  brew cask install appcleaner backblaze charles google-chrome imageoptim rowanj-gitx shiftit screenhero sketch qlstephen zeplin
+  brew cask install appcleaner backblaze charles google-chrome gpgtools imageoptim rowanj-gitx shiftit screenhero sketch qlstephen zeplin
 }
 
 #/ macos           Setup osx defaults: https://mths.be/osx

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -14,7 +14,7 @@ run() {
 #/ homebrews       Uninstalls core homebrew kegs
 homebrews() {
   printf "%Removing homebrews..\n"
-  brew uninstall bash-completion ctags git gpg heroku hub macvim ripgrep tidy-html5 tree watchman wget yarn
+  brew uninstall bash-completion ctags git heroku hub macvim ripgrep tidy-html5 tree watchman wget yarn
 }
 
 #/ bash            Removes .bash_profile, .bashrc and .inputrc
@@ -54,7 +54,7 @@ vim() {
 #/ casks           Uninstalls non App Store Mac applications
 casks() {
   printf "%sRemoving homebrew casks..\n"
-  brew cask uninstall appcleaner backblaze charles google-chrome imageoptim rowanj-gitx shiftit screenhero sketch qlstephen zeplin
+  brew cask uninstall appcleaner backblaze charles google-chrome gpgtools imageoptim rowanj-gitx shiftit screenhero sketch qlstephen zeplin
 }
 
 #/ world           Runs all of the uninstall commands


### PR DESCRIPTION
Since we utilize the GPG Tools app we can remove the executables from the heroku installs and move the installation of GPG Tools to brew cask.

FYI ran this through [rmtree](https://github.com/beeftornado/homebrew-rmtree) to yank out the lone home-brew dependencies in use.